### PR TITLE
Improved Debain install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,5 +13,9 @@ cmake -DCMAKE_BUILD_TYPE=Release ../
 #actually compile
 make
 
-#install it to system
-sudo make install
+# install
+if [[ -f /usr/bin/dpkg ]]; then                 # debian based distro
+  sudo checkinstall --default --install=yes
+else
+  sudo make install
+fi


### PR DESCRIPTION
If the distro being used is Debain based, using `checkinstall` will create a `.deb` file and installing is much easier and cleaner if you need to uninstall and do a clean install.
Need to add `checkinstall` in the dependency list for Debian.