### PR TITLE
Updated debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo pacman -Sy git gcc cmake make pkg-config pango cairo librsvg libxcb xcb-uti
 * Ubuntu
 
 ```bash
-sudo apt install git g++ make cmake pkg-config libpango1.0-dev libcairo2-dev librsvg2-dev libxcb1-dev libxcb-util-dev libpulse-dev libxkbcommon-dev libxkbcommon-x11-dev libconfig++-dev libxcb-keysyms1-dev libxcb-image0-dev papirus-icon-theme lxappearance unzip libxcb-randr0-dev libxcb-record0-dev libxcb-ewmh-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-cursor-dev
+sudo apt install git g++ make cmake checkinstall pkg-config libpango1.0-dev libcairo2-dev librsvg2-dev libxcb1-dev libxcb-util-dev libpulse-dev libxkbcommon-dev libxkbcommon-x11-dev libconfig++-dev libxcb-keysyms1-dev libxcb-image0-dev papirus-icon-theme lxappearance unzip libxcb-randr0-dev libxcb-record0-dev libxcb-ewmh-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-cursor-dev
 ```
 
 ## Installation


### PR DESCRIPTION
added `checkinstall` to make sure the install script works on debian if `checkinstall` is not installed.