### PR TITLE
fix taskbar going missing on randr resize down

### DIFF
--- a/lib/dpi.cpp
+++ b/lib/dpi.cpp
@@ -22,10 +22,7 @@ check_if_client_dpi_should_change_or_if_it_was_moved_to_another_screen(App *app,
                                                                        bool came_from_movement) {
     // FIGURE OUT WHICH SCREEN THE CLIENT BELONGS TO
     ScreenInformation *screen_client_overlaps_most = nullptr;
-    double greatest_overlap_percentage = 0;
-    if (!came_from_movement) {
-        greatest_overlap_percentage = -1;
-    }
+    double greatest_overlap_percentage = -1;
     for (auto screen: screens) {
         auto overlap_amount = calculate_overlap_percentage(client->bounds->x, client->bounds->y,
                                                            client->bounds->w, client->bounds->h,


### PR DESCRIPTION
Unless you do it gradually enough that it stays at least partially on-screen with every resize.

Reproduction steps:
```
Xvfb +extension RANDR :100 &
export DISPLAY=:100
winbar&
sleep 10
scrot
xrandr --newmode "1024x768_50.00"  51.89  1024 1064 1168 1312  768 769 772 791  -HSync +Vsync
xrandr --addmode screen 1024x768_50.00
xrandr -s 1024x768_50.00
scrot
```
Now compare the two screenshots taken by `scrot`. `winbar` is only visible on the first one.

This tiny fix ensures that when `came_from_movement` is `false`, a `screen_client_overlaps_most` will be set and the `on_any_screen_change` handler will be called.

I'm not at all sure that this fix is correct.
Perhaps the `greatest_overlap_percentage` should be set to `-1` in all cases instead? Doesn't it make sense to keep `client->screen_information` always up to date?
(which would also make the fix even smaller)
