### PR TITLE
Added Auto Resize to plugin commands.

### DIFF
--- a/src/pinned_icon_right_click.cpp
+++ b/src/pinned_icon_right_click.cpp
@@ -107,10 +107,10 @@ paint_icon(AppClient *client, cairo_t *cr, Container *container, bool dye) {
         text = "\uE718";
     } else if (data->text == "Unpin from taskbar") {
         text = "\uE77A";
+    }else if (data->text == "End task" || data->text == "End tasks") {
+      text = "\uF140";
     } else if (data->text == "Close window" || data->text == "Close all windows") {
         text = "\uE10A";
-    }else if (data->text == "End task" || data->text == "End tasks") {
-      text = "\u2298";
     } else if (data->surface != nullptr) {
         // TODO: gsurf here maybe (likely)?
         int height = cairo_image_surface_get_height(data->surface);
@@ -445,33 +445,31 @@ make_root(std::vector<DelayedSurfacePainting *> *delayed) {
     }
     
     if (!pinned_icon_data->windows_data_list.empty()) {
-        // CLOSE
-        auto data = new OptionData();
-        auto *close = root->child(FILL_SPACE, 30 * config->dpi);
-        close->when_paint = paint_option;
-        close->when_clicked = option_clicked;
-        data->option_type = option_data_type::CLOSE;
-
-        // ENDTASK
+        // ENDTASK 
+        auto *endTaskData = new OptionData();
         auto *endTask = root->child(FILL_SPACE, 30 * config->dpi);
         endTask->when_paint = paint_option;
         endTask->when_clicked = option_clicked;
-        
-        auto *endTaskData = new OptionData();
         endTaskData->option_type = option_data_type::ENDTASK;
-        
-        if (pinned_icon_data->windows_data_list.size() == 1) {
-            data->text = "Close window";
-            endTaskData->text = "End task";
-        } else {
-            data->text = "Close all windows";
-            endTaskData->text = "End tasks";
-        }
-        data->text_offset = 40 * config->dpi;
-        close->user_data = data;
-
         endTaskData->text_offset = 40 * config->dpi;
         endTask->user_data = endTaskData;
+        
+        // CLOSE 
+        auto *closeData = new OptionData();
+        auto *close = root->child(FILL_SPACE, 30 * config->dpi);
+        close->when_paint = paint_option;
+        close->when_clicked = option_clicked;
+        closeData->option_type = option_data_type::CLOSE;
+        closeData->text_offset = 40 * config->dpi;
+        close->user_data = closeData;
+
+        if (pinned_icon_data->windows_data_list.size() == 1) {
+            endTaskData->text = "End task";
+            closeData->text = "Close window";
+        } else {
+            endTaskData->text = "End tasks";
+            closeData->text = "Close all windows";
+        }
     }
     
     auto *end_pad = root->child(FILL_SPACE, pad);

--- a/src/plugins_menu.cpp
+++ b/src/plugins_menu.cpp
@@ -622,6 +622,21 @@ void on_plugin_sent_text(Subprocess *cc) {
                         plugin_error(tokenizer,
                                      "This is because \"set_icon_text\" was not followed by a single character string as was expected.");
                     }
+                } else if (token.text == "resize_me") {
+                  auto data = (PluginData*) taskbar_plugin_button->user_data;
+                  if (!data->icon_text.empty()) {
+                    auto client = client_by_name(app, "taskbar");
+                    PangoLayout *layout = get_cached_pango_font(client->cr, "Segoe MDL2 Assets Mod", 10 * config->dpi, PangoWeight::PANGO_WEIGHT_NORMAL);
+
+                    pango_layout_set_text(layout, data->icon_text.c_str(), data->icon_text.size());
+                    int width;
+                    int height;
+                    pango_layout_get_pixel_size_safe(layout, &width, &height);
+          
+                    taskbar_plugin_button->wanted_bounds.w = width + 16 * config->dpi;
+                    client_layout(app, client);
+                    request_refresh(app, client);
+                  }
                 } else if (token.text == "set_text_icon_color") {
                     token = get_token(tokenizer);
                     if (token.type == TokenType::STRING) {


### PR DESCRIPTION
"resize_me" command automatically resizes the width of plugin widget to match size of title.

![image](https://github.com/user-attachments/assets/d69de59d-b94f-45cb-818d-eaa5a0b5eaaa)
Width of plugin widget was resized to fit "Lorem Ipsum" using "resize_me" command sent from .config/winbar/plugins/test.plugin