### PR TITLE
[Improvement] Search Menu calculator now supports '^' alongside pow().

### DIFF
--- a/lib/picomath.hpp
+++ b/lib/picomath.hpp
@@ -399,7 +399,7 @@ class Expression {
     auto parsePrefixUnaryOperator() -> Result {
         char op = consume();
         consumeSpace();
-        Result unary = parseSubExpression();
+        Result unary = parseExponentiation();
         if (PM_UNLIKELY(unary.isError())) {
             return unary;
         }
@@ -541,7 +541,7 @@ class Expression {
 
     auto parseMultiplication() -> Result {
         consumeSpace();
-        Result left = parseSubExpression();
+        Result left = parseExponentiation();
         if (PM_UNLIKELY(left.isError())) {
             return left;
         }
@@ -549,7 +549,7 @@ class Expression {
         while (*str == '*' || *str == '/') {
             char op = consume();
             consumeSpace();
-            Result right = parseSubExpression();
+            Result right = parseExponentiation();
             if (PM_UNLIKELY(right.isError())) {
                 return right;
             }
@@ -559,6 +559,28 @@ class Expression {
                 left.result /= right.result;
             }
             consumeSpace();
+        }
+        return left;
+    }
+
+    // New function to handle exponentiation (^ operator)
+    auto parseExponentiation() -> Result {
+        consumeSpace();
+        Result left = parseSubExpression();
+        if (PM_UNLIKELY(left.isError())) {
+            return left;
+        }
+        consumeSpace();
+        
+        // Exponentiation is right-associative, so we handle it recursively
+        if (*str == '^') {
+            consume();
+            consumeSpace();
+            Result right = parseExponentiation(); // Right-associative recursion
+            if (PM_UNLIKELY(right.isError())) {
+                return right;
+            }
+            left.result = std::pow(left.result, right.result);
         }
         return left;
     }

--- a/src/search_menu.cpp
+++ b/src/search_menu.cpp
@@ -476,7 +476,7 @@ bool contains_operator(const std::string& input) {
         return true;
     }
     for (char ch : input) {
-        if (ch == '+' || ch == '-' || ch == '*' || ch == '/') {
+        if (ch == '+' || ch == '-' || ch == '*' || ch == '/' || ch == '^') {
             return true;
         }
     }


### PR DESCRIPTION
Search Menu calculator now supports '^' alongside pow(x, y).
![image](https://github.com/user-attachments/assets/fb1c2a42-4560-4a5d-b979-7f3fa2d96018)

