### PR TITLE
Fix NM wifi calls on non wireless devices

### DIFF
--- a/src/wifi_backend.cpp
+++ b/src/wifi_backend.cpp
@@ -93,6 +93,7 @@ bool wifi_wpa_start(App *app, const std::string &interface) {
     std::string wpa_supplicant_path = "/var/run/wpa_supplicant/" + interface;
     auto link = new InterfaceLink();
     link->interface = interface;
+    link->is_wireless = true;
     link->wpa_message_sender = wpa_ctrl_open(wpa_supplicant_path.data());
     if (!link->wpa_message_sender)
         return false;

--- a/src/wifi_backend.h
+++ b/src/wifi_backend.h
@@ -53,6 +53,7 @@ struct ScanResult {
 struct InterfaceLink {
     std::string interface;
     std::string device_object_path;
+    bool is_wireless = false;
     wpa_ctrl *wpa_message_sender = nullptr;
     wpa_ctrl *wpa_message_listener = nullptr;
     std::vector<ScanResult> results;


### PR DESCRIPTION
winbar spammed DBus errors like:

```
failed get: AccessPoints, error: No such interface “org.freedesktop.NetworkManager.Device.Wireless”
failed get: LastScan, error: No such interface “org.freedesktop.NetworkManager.Device.Wireless”
````

(seen right after refreshes)

NM enumerated non wireless devices but winbar queried org.freedesktop.NetworkManager.Device.Wireless properties/methods unconditionally 