### PR TITLE
Fix crash from zero length bounce animation

### DIFF
--- a/src/taskbar.cpp
+++ b/src/taskbar.cpp
@@ -5758,7 +5758,7 @@ void remove_window(App *app, xcb_window_t window) {
                 }
                 data->animation_bounce_amount = 0;
                 data->animation_bounce_direction = 0;
-                client_create_animation(app, entity, &data->animation_bounce_amount, data->lifetime, 0, 0, nullptr, 0);
+                client_create_animation(app, entity, &data->animation_bounce_amount, data->lifetime, 0, 1, nullptr, 0);
                 
                 delete data->windows_data_list[i];
                 data->windows_data_list.erase(data->windows_data_list.begin() + i);


### PR DESCRIPTION
crashes were occurring when window state changed too quickly (notably Telegram image fullscreen, only application I could reproduce this on). The crash showed up as a `std::vector` bounds assert in the bounce path after animation scalar math became invalid

Root cause was an apparent length = 0 animation for animation_bounce_amount which allowed invalid scalar generation in the animation loop